### PR TITLE
Allow PHP 8+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "php": ">=7.2",
     "ext-dom": "20031129",
-    "ext-libxml": "^7.2"
+    "ext-libxml": "^7.2 || ^8.0"
   },
   "require-dev": {
     "ext-mbstring": "^7.2",


### PR DESCRIPTION
PHP 8+ is blocked by the current ext-libxml requirement. This allows for v8+ versions of libxml.

I tested this in a fork with my own project and didn't run into any issues.